### PR TITLE
test(booking): Add test case to test seat expiry flow (CONF-105 #14)

### DIFF
--- a/src/test/java/com/sherwin/conference/bookingsystem/domain/feature/SeatExpiryDomainServiceTest.java
+++ b/src/test/java/com/sherwin/conference/bookingsystem/domain/feature/SeatExpiryDomainServiceTest.java
@@ -3,8 +3,15 @@ package com.sherwin.conference.bookingsystem.domain.feature;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.verify;
 
+import com.sherwin.conference.bookingsystem.domain.ReservationResult;
+import com.sherwin.conference.bookingsystem.domain.Talk;
+import com.sherwin.conference.bookingsystem.domain.event.ConferenceApplicationEvent;
 import com.sherwin.conference.bookingsystem.domain.event.ConferenceApplicationEvent.SeatReserved;
 import com.sherwin.conference.bookingsystem.domain.spi.ExpireOldReservationsAction;
+import com.sherwin.conference.bookingsystem.entity.TicketEntity;
+import com.sherwin.conference.bookingsystem.infrastructure.repository.TicketRepository;
+import com.sherwin.conference.bookingsystem.infrastructure.service.TalkService;
+import com.sherwin.conference.bookingsystem.infrastructure.service.TicketService;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.concurrent.Callable;
@@ -17,11 +24,12 @@ import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 @SpringBootTest
 public class SeatExpiryDomainServiceTest {
 
-  @MockitoBean private ExpireOldReservationsAction expireOldReservationsAction;
+  @MockitoSpyBean private ExpireOldReservationsAction expireOldReservationsAction;
 
   @MockitoBean(name = "taskScheduler")
   private ScheduledExecutorService executorService;
@@ -30,6 +38,14 @@ public class SeatExpiryDomainServiceTest {
   private ExecutorService virtualThreadExecutorService;
 
   @Autowired private SeatExpiryDomainService seatExpiryDomainService;
+
+  @Autowired TalkService talkDomainService;
+
+  @Autowired TicketService ticketDomainService;
+
+  @MockitoSpyBean DomainEventHandler eventHandler;
+
+  @Autowired TicketRepository ticketRepository;
 
   @Test
   void testScheduleSeatExpiry() throws Exception {
@@ -67,5 +83,33 @@ public class SeatExpiryDomainServiceTest {
         598_000,
         seatExpiryDomainService.calculateDelayForSeatExpiryScheduledJobInMillis(
             reservedAt, expireAfterDuration, schedulerNowTime));
+  }
+
+  @Test
+  void testSeatExpiryFlow() throws Exception {
+    String name = "talk1";
+    int totalSeats = 10;
+    ArgumentCaptor<ConferenceApplicationEvent> seatReservedArgumentCaptor =
+        ArgumentCaptor.forClass(ConferenceApplicationEvent.class);
+    ArgumentCaptor<Runnable> virtualThreadJobCaptor = ArgumentCaptor.forClass(Runnable.class);
+    ArgumentCaptor<Callable<Long>> virtualThreadCallable = ArgumentCaptor.forClass(Callable.class);
+    Talk talk = talkDomainService.create(name, totalSeats);
+    String userEmail = "testuser@testuser.com";
+
+    String apiReturn = ticketDomainService.reserveTicket(talk.id(), userEmail);
+    verify(eventHandler).handleEvent(seatReservedArgumentCaptor.capture());
+    verify(executorService).schedule(virtualThreadJobCaptor.capture(), anyLong(), any());
+    virtualThreadJobCaptor.getValue().run();
+    verify(virtualThreadExecutorService).submit(virtualThreadCallable.capture());
+    ConferenceApplicationEvent conferenceApplicationEvent = seatReservedArgumentCaptor.getValue();
+    switch (conferenceApplicationEvent) {
+      case SeatReserved seatReserved -> {
+        virtualThreadCallable.getValue().call();
+        TicketEntity ticket = ticketRepository.findById(seatReserved.ticketId()).orElseThrow();
+        Assertions.assertEquals(
+            new ReservationResult.Expired().toString(), ticket.getStatus().toString());
+      }
+      case ConferenceApplicationEvent.SeatExpired _ -> IO.println("Nothing");
+    }
   }
 }


### PR DESCRIPTION
Test the flow and transition of a seat from reserved to expired by checking the value of the status field in the database. The value of the status column should change from RESERVED to EXPIRED